### PR TITLE
Fix unresponsive navigation bar for language switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,11 @@
             </div>
             <nav>
                 <ul>
-                    <li><a href="" class="nav-link active">Home</a></li>
-                    <li><a href="" class="nav-link">About</a></li>
-                    <li><a href="" class="nav-link">Skills</a></li>
-                    <li><a href="" class="nav-link">Projects</a></li>
-                    <li><a href="" class="nav-link">Contact</a></li>
+                    <li><a href="#home" class="nav-link active">Home</a></li>
+                    <li><a href="#about" class="nav-link">About</a></li>
+                    <li><a href="#skills" class="nav-link">Skills</a></li>
+                    <li><a href="#projects" class="nav-link">Projects</a></li>
+                    <li><a href="#contact" class="nav-link">Contact</a></li>
                 </ul>
             </nav>
             <button id="theme-toggle" aria-label="Toggle dark/light mode">
@@ -64,7 +64,7 @@
                     <a href="Diego_Lara_CV_ENG.pdf" class="btn primary-btn cv-link" target="_blank">
                         <span class="iconify" data-icon="tabler:file-type-pdf"></span> <span class="en">View CV</span><span class="es">Ver CV</span>
                     </a>
-                    <a href="" class="btn secondary-btn">
+                    <a href="#contact" class="btn secondary-btn">
                         <span class="iconify" data-icon="tabler:mail"></span> <span class="en">Contact Me</span><span class="es">Contáctame</span>
                     </a>
                 </div>
@@ -416,24 +416,5 @@
 
     <script src="script.js"></script>
     <script src="https://code.iconify.design/2/2.2.1/iconify.min.js"></script>
-    <script>
-        // Update CV link based on language
-        function updateCVLink() {
-            const cvLink = document.querySelector('.cv-link');
-            const isSpanish = document.documentElement.lang === 'es';
-            cvLink.href = isSpanish ? 'Diego_Lara_CV.pdf' : 'Diego_Lara_CV_ENG.pdf';
-        }
-
-        // Listen for language toggle
-        const langToggle = document.getElementById('lang-toggle');
-        if (langToggle) {
-            langToggle.addEventListener('click', function() {
-                setTimeout(updateCVLink, 100);
-            });
-        }
-
-        // Set initial CV link
-        updateCVLink();
-    </script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -99,21 +99,37 @@ document.addEventListener("DOMContentLoaded", () => {
   // Language toggle functionality
   const langToggle = document.getElementById("lang-toggle");
   const langText = langToggle.querySelector(".lang-text");
-  
+
+  function syncHtmlLangAttribute() {
+    const isSpanish = document.body.classList.contains("spanish");
+    document.documentElement.lang = isSpanish ? "es" : "en";
+  }
+
+  function updateCVLinkForLanguage() {
+    const cvLink = document.querySelector(".cv-link");
+    if (!cvLink) return;
+    const isSpanish = document.body.classList.contains("spanish");
+    cvLink.href = isSpanish ? "Diego_Lara_CV.pdf" : "Diego_Lara_CV_ENG.pdf";
+  }
+
   // Check for saved language preference
   const currentLang = localStorage.getItem("language") || "en";
-  
-  // Apply the language
+
+  // Apply the language preference on load
   if (currentLang === "es") {
     document.body.classList.add("spanish");
     langText.textContent = "ES";
+  } else {
+    langText.textContent = "EN";
   }
-  
+  syncHtmlLangAttribute();
+  updateCVLinkForLanguage();
+
   // Toggle language when button is clicked
   langToggle.addEventListener("click", () => {
     document.body.classList.toggle("spanish");
-    
-    // Update button text
+
+    // Update button text and persist preference
     if (document.body.classList.contains("spanish")) {
       langText.textContent = "ES";
       localStorage.setItem("language", "es");
@@ -121,6 +137,10 @@ document.addEventListener("DOMContentLoaded", () => {
       langText.textContent = "EN";
       localStorage.setItem("language", "en");
     }
+
+    // Keep <html lang> and CV link in sync
+    syncHtmlLangAttribute();
+    updateCVLinkForLanguage();
   });
 
   // Smooth scrolling for navigation links


### PR DESCRIPTION
Wired navigation links and hero contact button to scroll to sections and fixed language-based CV link selection.

The navigation links and hero contact button had empty `href` attributes, preventing them from navigating. The CV link logic was also not correctly integrated with the language toggle and initial page load, causing it to not update based on the selected language.

---
<a href="https://cursor.com/background-agent?bcId=bc-165f8b7a-ade0-49f1-9f9a-13d879520127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-165f8b7a-ade0-49f1-9f9a-13d879520127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

